### PR TITLE
Add: support for deserializing multiple instances of a type

### DIFF
--- a/src/main/RdfMapper.ts
+++ b/src/main/RdfMapper.ts
@@ -18,12 +18,12 @@ export class RdfMapper {
      * @param type
      * @param ttlData
      */
-    public static async deserializeAsync<T>(type: { new(): T }, ttlData: string): Promise<T> {
+    public static async deserializeAsync<T>(type: { new(): T }, ttlData: string): Promise<T|T[]> {
         const deserializeProcessor: DeserializerProcessor = new DeserializerProcessor();
         return deserializeProcessor.deserializeAsync(type, ttlData);
     }
 
-    public static deserialize<T>(type: { new(): T }, ttlData: string): T {
+    public static deserialize<T>(type: { new(): T }, ttlData: string): T|T[] {
         const deserializeProcessor: DeserializerProcessor = new DeserializerProcessor();
         return deserializeProcessor.deserialize(type, ttlData);
     }

--- a/src/test/deserialize.spec.ts
+++ b/src/test/deserialize.spec.ts
@@ -1,5 +1,5 @@
 import {RdfMapper} from '../main/RdfMapper';
-import {Person, personTTL, recipeVideoTTL} from './models/models';
+import {Person, personsTTL, personTTL, recipeVideoTTL} from './models/models';
 import {oneToOneRelationship, PersonHasAddress} from './models/oneToOneModels';
 import {Recipe, Video} from './models/recipes';
 
@@ -14,7 +14,7 @@ function logResult(assertName: string, result: any, logOnlyMe = false) {
 
 describe('Test TTL Deserialization', () => {
     it('Deserialize basic ttl (async)', async (done) => {
-        const instance: Person = await RdfMapper.deserializeAsync(Person, personTTL);
+        const instance: Person = await RdfMapper.deserializeAsync(Person, personTTL) as Person;
 
         // console.log(JSON.stringify(instance));
         expect(instance.firstName).toEqual('David');
@@ -28,7 +28,7 @@ describe('Test TTL Deserialization', () => {
     });
 
     it('Deserialize basic ttl', () => {
-        const instance: Person = RdfMapper.deserialize(Person, personTTL);
+        const instance: Person|Person[] = RdfMapper.deserialize(Person, personTTL) as Person;
 
         // console.log(JSON.stringify(instance));
         expect(instance.firstName).toEqual('David');
@@ -39,8 +39,28 @@ describe('Test TTL Deserialization', () => {
         expect(instance.title).toEqual('Mr');
     });
 
+    it('Deserialize basic ttl with more than one instance', () => {
+        const instance: Person|Person[] = RdfMapper.deserialize(Person, personsTTL);
+        // console.log(JSON.stringify(instance));
+        expect(typeof instance).toEqual('array');
+
+        expect(instance[0].firstName).toEqual('David');
+        expect(instance[0].uuid).toEqual('1234567');
+        expect(instance[0].name).toEqual('David Banner');
+        expect(instance[0].nick).toEqual('hulk');
+        expect(instance[0].surname).toEqual('Banner');
+        expect(instance[0].title).toEqual('Mr');
+
+        expect(instance[1].firstName).toEqual('Sally');
+        expect(instance[1].uuid).toEqual('7654321');
+        expect(instance[1].name).toEqual('Sally Flickard');
+        expect(instance[1].nick).toEqual('punchy');
+        expect(instance[1].surname).toEqual('Flickard');
+        expect(instance[1].title).toEqual('Ms');
+    });
+
     it('Deserialize ttl with one-to-one relationship (async)', async (done) => {
-        const instance: PersonHasAddress = await RdfMapper.deserializeAsync(PersonHasAddress, oneToOneRelationship);
+        const instance: PersonHasAddress = await RdfMapper.deserializeAsync(PersonHasAddress, oneToOneRelationship) as PersonHasAddress;
         expect(instance.uuid).toEqual('person-uuid');
         expect(instance.name).toEqual('John');
         expect(instance.address.uuid).toEqual('address-uuid');
@@ -49,7 +69,7 @@ describe('Test TTL Deserialization', () => {
     });
 
     it('Deserialize ttl with one-to-one relationship', () => {
-        const instance: PersonHasAddress = RdfMapper.deserialize(PersonHasAddress, oneToOneRelationship);
+        const instance: PersonHasAddress = RdfMapper.deserialize(PersonHasAddress, oneToOneRelationship) as PersonHasAddress;
         expect(instance.uuid).toEqual('person-uuid');
         expect(instance.name).toEqual('John');
         expect(instance.address.uuid).toEqual('address-uuid');
@@ -57,7 +77,7 @@ describe('Test TTL Deserialization', () => {
     });
 
     it('Deserialize blank nodes (async)', async (done) => {
-       const recipe: Recipe = await RdfMapper.deserializeAsync(Recipe, recipeVideoTTL);
+       const recipe: Recipe = await RdfMapper.deserializeAsync(Recipe, recipeVideoTTL) as Recipe;
        expect(recipe instanceof Recipe).toBeTruthy();
        expect(recipe.video).toBeDefined();
        expect(recipe.video instanceof Video).toBeTruthy();
@@ -68,7 +88,7 @@ describe('Test TTL Deserialization', () => {
     });
 
     it('Deserialize blank nodes',  () => {
-        const recipe: Recipe = RdfMapper.deserialize(Recipe, recipeVideoTTL);
+        const recipe: Recipe = RdfMapper.deserialize(Recipe, recipeVideoTTL) as Recipe;
         expect(recipe instanceof Recipe).toBeTruthy();
         expect(recipe.video).toBeDefined();
         expect(recipe.video instanceof Video).toBeTruthy();

--- a/src/test/dieGracefully.spec.ts
+++ b/src/test/dieGracefully.spec.ts
@@ -16,7 +16,7 @@ function logResult(assertName: string, result: any) {
 describe('Meaningful Exceptions should be thrown', () => {
     it('Should throw TurtleParseError when turtle is invalid', async (done) => {
         try {
-            const instance: Person = await RdfMapper.deserializeAsync(Person, invalidTTL);
+            const instance: Person|Person[] = await RdfMapper.deserializeAsync(Person, invalidTTL);
         } catch (e) {
             expect(e instanceof TurtleParseError).toBeTruthy();
             expect(e.name).toEqual('TurtleParseError');


### PR DESCRIPTION
Add support for deserializing multiple instances of a type when present in TTL source

This PR contains code that adds support for the deserializer to instantiate multiple distinct type instances when present in a source ttl.

The interface is slightly modified to support returning either a type T when only a single instance is present in the source or an array of type T when multiple. ```T | T[]```